### PR TITLE
Add SpecificItemPropertyPairQueryHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,13 @@ const http = require( 'http' );
 const https = require( 'https' );
 
 const QueryHandlerChain = require( './lib/QueryHandlerChain' );
+const SpecificItemPropertyPairQueryHandler = require( './lib/SpecificItemPropertyPairQueryHandler' );
 
 const port = process.argv[ 2 ] || 8080;
 
-const queryHandlerChain = new QueryHandlerChain( [] );
+const queryHandlerChain = new QueryHandlerChain( [
+	new SpecificItemPropertyPairQueryHandler(),
+] );
 
 http.createServer( function ( clientRequest, clientResponse ) {
 	const extraResponseHeaders = {};

--- a/lib/SpecificItemPropertyPairQueryHandler.js
+++ b/lib/SpecificItemPropertyPairQueryHandler.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const SparqlParser = require( 'sparqljs' ).Parser;
+const { namespaceMap, allNamespaces } = require( './rdfNamespaces' );
+const SimpleQueryResult = require( './SimpleQueryResult' );
+
+const parser = new SparqlParser( { prefixes: allNamespaces } );
+
+module.exports = class SpecificItemPropertyPairQueryHandler {
+
+	canHandle( query ) {
+		const parsedQuery = parser.parse( query );
+		if ( parsedQuery.queryType !== 'SELECT' || !this.hasSingleTriple( parsedQuery ) ) {
+			return false;
+		}
+
+		const triple = parsedQuery.where[ 0 ].triples[ 0 ];
+		return triple.subject.termType === 'NamedNode' &&
+			triple.subject.id.startsWith( namespaceMap.Wikidata.wd ) &&
+			triple.predicate.termType === 'NamedNode' &&
+			triple.predicate.id.startsWith( namespaceMap.Wikidata.wdt ) &&
+			triple.object.termType === 'Variable';
+	}
+
+	hasSingleTriple( query ) {
+		return query.where &&
+			query.where.length === 1 &&
+			query.where[ 0 ].triples.length === 1;
+
+	}
+
+	getResult() {
+		return new SimpleQueryResult();
+	}
+
+};

--- a/lib/rdfNamespaces.js
+++ b/lib/rdfNamespaces.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// copied from https://github.com/wikimedia/wikidata-query-gui/blob/bd2b5688367541b816dc576010772598258c581f/wikibase/queryService/RdfNamespaces.js
+
+const namespaceMap = {
+	Wikidata: {
+		wikibase: 'http://wikiba.se/ontology#',
+		wd: 'http://www.wikidata.org/entity/',
+		wdt: 'http://www.wikidata.org/prop/direct/',
+		wdtn: 'http://www.wikidata.org/prop/direct-normalized/',
+		wds: 'http://www.wikidata.org/entity/statement/',
+		p: 'http://www.wikidata.org/prop/',
+		wdref: 'http://www.wikidata.org/reference/',
+		wdv: 'http://www.wikidata.org/value/',
+		ps: 'http://www.wikidata.org/prop/statement/',
+		psv: 'http://www.wikidata.org/prop/statement/value/',
+		psn: 'http://www.wikidata.org/prop/statement/value-normalized/',
+		pq: 'http://www.wikidata.org/prop/qualifier/',
+		pqv: 'http://www.wikidata.org/prop/qualifier/value/',
+		pqn: 'http://www.wikidata.org/prop/qualifier/value-normalized/',
+		pr: 'http://www.wikidata.org/prop/reference/',
+		prv: 'http://www.wikidata.org/prop/reference/value/',
+		prn: 'http://www.wikidata.org/prop/reference/value-normalized/',
+		wdno: 'http://www.wikidata.org/prop/novalue/',
+		wdata: 'http://www.wikidata.org/wiki/Special:EntityData/',
+	},
+	W3C: {
+		rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+		rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+		owl: 'http://www.w3.org/2002/07/owl#',
+		skos: 'http://www.w3.org/2004/02/skos/core#',
+		xsd: 'http://www.w3.org/2001/XMLSchema#',
+		prov: 'http://www.w3.org/ns/prov#',
+	},
+	'Social/Other': {
+		schema: 'http://schema.org/',
+		geo: 'http://www.opengis.net/ont/geosparql#',
+		geof: 'http://www.opengis.net/def/geosparql/function/',
+	},
+	Blazegraph: {
+		bd: 'http://www.bigdata.com/rdf#',
+		bds: 'http://www.bigdata.com/rdf/search#',
+		gas: 'http://www.bigdata.com/rdf/gas#',
+		hint: 'http://www.bigdata.com/queryHints#',
+	},
+};
+
+let allNamespaces = {};
+
+Object.values( namespaceMap ).forEach( ( ( prefixes ) => {
+	allNamespaces = Object.assign( allNamespaces, prefixes );
+} ) );
+
+module.exports = {
+	allNamespaces, namespaceMap,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3614,6 +3614,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "n3": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.5.0.tgz",
+      "integrity": "sha512-k4R/EOMnnRYFt+hXgqyKOHjzmshaLuHUFgrz5nsp9nAojCZuAHrro/DsIM2tS0Bgx6ed7DM5Ks3q2teJ8n7HnQ==",
+      "requires": {
+        "queue-microtask": "^1.1.2"
+      }
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -4025,6 +4033,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
     },
     "ramda": {
       "version": "0.27.0",
@@ -4677,6 +4690,14 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "sparqljs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.0.3.tgz",
+      "integrity": "sha512-/hy2ihyn6YaYdLqnfdG8En6n8/NJVfRGI//AWPh6Anbfxfz89vv9ATEa8taE+SpOBuh6pSYEhIYKPkVRkXNBNg==",
+      "requires": {
+        "n3": "^1.5.0"
+      }
     },
     "spdx-correct": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "eslint": "^7.5.0",
     "eslint-config-wikimedia": "^0.16.2",
     "jest": "^26.1.0"
+  },
+  "dependencies": {
+    "sparqljs": "^3.0.3"
   }
 }

--- a/tests/SpecificItemPropertyPairQueryHandler.spec.js
+++ b/tests/SpecificItemPropertyPairQueryHandler.spec.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const SpecificItemPropertyPairQueryHandler = require( '../lib/SpecificItemPropertyPairQueryHandler' );
+const SimpleQueryResult = require( '../lib/SimpleQueryResult' );
+
+describe( 'SpecificItemPropertyPairQueryHandler', () => {
+
+	it( 'can handle queries with a single triple for values of a specific item property pair', () => {
+		const query = 'SELECT ?values { wd:Q42 wdt:P31 ?values. }';
+		const handler = new SpecificItemPropertyPairQueryHandler();
+		expect( handler.canHandle( query ) ).toBeTruthy();
+	} );
+
+	it.each( [
+		'ASK { wd:Q42 wdt:P31 wd:Q5. }',
+		'SELECT ?item { ?item wdt:P31 wd:Q5. }',
+		'SELECT ?values { wd:Q42 wdt:P106 ?values. wd:Q892 wdt:P106 ?values. }',
+	] )( 'cannot handle other queries: %s', ( query ) => {
+		expect( ( new SpecificItemPropertyPairQueryHandler() ).canHandle( query ) ).toBeFalsy();
+	} );
+
+	it( 'is a simple query', () => {
+		expect( ( new SpecificItemPropertyPairQueryHandler() ).getResult() )
+			.toBeInstanceOf( SimpleQueryResult );
+	} );
+
+} );


### PR DESCRIPTION
This adds the first "simple" query handler for getting values of
specific item property pairs and does the necessary setup such as:
* installing sparqljs
* adding the wikidata rdf namespaces (copied from the qs ui repo)
* setting up a sparqljs parser

Missing: Actually wiring it up in index.js