### PR TITLE
Add OptimizingHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const http = require( 'http' );
 const https = require( 'https' );
 
+const OptimizingHandler = require( './lib/OptimizingHandler' );
 const QueryHandlerChain = require( './lib/QueryHandlerChain' );
 const SpecificItemPropertyPairQueryHandler = require( './lib/SpecificItemPropertyPairQueryHandler' );
 
@@ -10,6 +11,7 @@ const port = process.argv[ 2 ] || 8080;
 
 const queryHandlerChain = new QueryHandlerChain( [
 	new SpecificItemPropertyPairQueryHandler(),
+	new OptimizingHandler(),
 ] );
 
 function isJsonType( mimeType ) {

--- a/lib/OptimizingHandler.js
+++ b/lib/OptimizingHandler.js
@@ -58,8 +58,8 @@ module.exports = class OptimizingHandler {
 				return;
 			}
 
-			// we actually have an expression of the form FILTER(YEAR(?date) = 2020)
-			// rewrite it to FILTER(?date >= "2020-00-00"^^xsd:dateTime && ?date < "2021-00-00"^^xsd:dateTime)
+			// we actually have an expression of the form FILTER(YEAR(?date) = 2020); rewrite it to
+			// FILTER(?date >= "2020-00-00"^^xsd:dateTime && ?date < "2021-00-00"^^xsd:dateTime)
 			hasChange = true;
 			const variable = lhs.args[ 0 ];
 			const dateTime = {

--- a/lib/OptimizingHandler.js
+++ b/lib/OptimizingHandler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const SparqlGenerator = require( 'sparqljs' ).Generator;
+const traverse = require( 'traverse' );
 const { allPrefixes } = require( './rdfNamespaces' );
 const WdqsRequest = require( './WdqsRequest' );
 
@@ -18,91 +19,90 @@ module.exports = class OptimizingHandler {
 		}
 
 		let hasChange = false;
-		const newQuery = {
-			...parsedQuery,
-			where: parsedQuery.where.map( ( element ) => {
-				if ( element.type !== 'filter' ||
-					element.expression.type !== 'operation' ||
-					element.expression.operator !== '=' ||
-					element.expression.args.length !== 2
-				) {
-					return element;
-				}
-				let [ lhs, rhs ] = element.expression.args;
-				if ( lhs.type !== 'operation' ) {
-					// try swapping them
-					[ lhs, rhs ] = [ rhs, lhs ];
-				}
-				if ( lhs.type !== 'operation' ||
-					lhs.operator !== 'year' ||
-					lhs.args.length !== 1 ||
-					lhs.args[ 0 ].termType !== 'Variable' ||
-					rhs.termType !== 'Literal' ||
-					rhs.datatype.value !== 'http://www.w3.org/2001/XMLSchema#integer'
-				) {
-					return element;
-				}
+		/* eslint-disable array-callback-return */ // false positive
+		const newQuery = traverse( parsedQuery ).map( function ( element ) {
+			if ( element.type !== 'filter' ||
+				element.expression.type !== 'operation' ||
+				element.expression.operator !== '=' ||
+				element.expression.args.length !== 2
+			) {
+				return;
+			}
+			let [ lhs, rhs ] = element.expression.args;
+			if ( lhs.type !== 'operation' ) {
+				// try swapping them
+				[ lhs, rhs ] = [ rhs, lhs ];
+			}
+			if ( lhs.type !== 'operation' ||
+				lhs.operator !== 'year' ||
+				lhs.args.length !== 1 ||
+				lhs.args[ 0 ].termType !== 'Variable' ||
+				rhs.termType !== 'Literal' ||
+				rhs.datatype.value !== 'http://www.w3.org/2001/XMLSchema#integer'
+			) {
+				return;
+			}
 
-				let year;
-				try {
-					year = parseInt( rhs.value );
-				} catch ( e ) {
-					return element;
-				}
-				if ( year.toString() !== rhs.value ) {
-					// precision issues or garbage at end of input
-					return element;
-				}
-				if ( year === year + 1 ) {
-					// precision issues
-					return element;
-				}
+			let year;
+			try {
+				year = parseInt( rhs.value );
+			} catch ( e ) {
+				return;
+			}
+			if ( year.toString() !== rhs.value ) {
+				// precision issues or garbage at end of input
+				return;
+			}
+			if ( year === year + 1 ) {
+				// precision issues
+				return;
+			}
 
-				// we actually have an expression of the form FILTER(YEAR(?date) = 2020)
-				// rewrite it to FILTER(?date >= "2020-00-00"^^xsd:dateTime && ?date < "2021-00-00"^^xsd:dateTime)
-				hasChange = true;
-				const variable = lhs.args[ 0 ];
-				const dateTime = {
-					termType: 'NamedNode',
-					value: 'http://www.w3.org/2001/XMLSchema#dateTime',
-				};
-				return {
-					type: 'filter',
-					expression: {
-						type: 'operation',
-						operator: '&&',
-						args: [
-							{
-								type: 'operation',
-								operator: '>=',
-								args: [
-									variable,
-									{
-										termType: 'Literal',
-										value: `${year}-00-00`,
-										language: '',
-										datatype: dateTime,
-									},
-								],
-							},
-							{
-								type: 'operation',
-								operator: '<',
-								args: [
-									variable,
-									{
-										termType: 'Literal',
-										value: `${year + 1}-00-00`,
-										language: '',
-										datatype: dateTime,
-									},
-								],
-							},
-						],
-					},
-				};
-			} ),
-		};
+			// we actually have an expression of the form FILTER(YEAR(?date) = 2020)
+			// rewrite it to FILTER(?date >= "2020-00-00"^^xsd:dateTime && ?date < "2021-00-00"^^xsd:dateTime)
+			hasChange = true;
+			const variable = lhs.args[ 0 ];
+			const dateTime = {
+				termType: 'NamedNode',
+				value: 'http://www.w3.org/2001/XMLSchema#dateTime',
+			};
+			this.update( {
+				type: 'filter',
+				expression: {
+					type: 'operation',
+					operator: '&&',
+					args: [
+						{
+							type: 'operation',
+							operator: '>=',
+							args: [
+								variable,
+								{
+									termType: 'Literal',
+									value: `${year}-00-00`,
+									language: '',
+									datatype: dateTime,
+								},
+							],
+						},
+						{
+							type: 'operation',
+							operator: '<',
+							args: [
+								variable,
+								{
+									termType: 'Literal',
+									value: `${year + 1}-00-00`,
+									language: '',
+									datatype: dateTime,
+								},
+							],
+						},
+					],
+				},
+			} );
+		} );
+		/* eslint-enable */
 
 		if ( hasChange ) {
 			return new WdqsRequest( this.generator.stringify( newQuery ) );

--- a/lib/OptimizingHandler.js
+++ b/lib/OptimizingHandler.js
@@ -53,6 +53,10 @@ module.exports = class OptimizingHandler {
 					// precision issues or garbage at end of input
 					return element;
 				}
+				if ( year === year + 1 ) {
+					// precision issues
+					return element;
+				}
 
 				// we actually have an expression of the form FILTER(YEAR(?date) = 2020)
 				// rewrite it to FILTER(?date >= "2020-00-00"^^xsd:dateTime && ?date < "2021-00-00"^^xsd:dateTime)

--- a/lib/OptimizingHandler.js
+++ b/lib/OptimizingHandler.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const SparqlGenerator = require( 'sparqljs' ).Generator;
+const { allPrefixes } = require( './rdfNamespaces' );
+const WdqsRequest = require( './WdqsRequest' );
+
+module.exports = class OptimizingHandler {
+
+	constructor() {
+		this.generator = new SparqlGenerator( { prefixes: allPrefixes } );
+	}
+
+	handle( query, parsedQuery ) {
+		if ( !parsedQuery ||
+			parsedQuery.queryType !== 'SELECT'
+		) {
+			return;
+		}
+
+		let hasChange = false;
+		const newQuery = {
+			...parsedQuery,
+			where: parsedQuery.where.map( ( element ) => {
+				if ( element.type !== 'filter' ||
+					element.expression.type !== 'operation' ||
+					element.expression.operator !== '=' ||
+					element.expression.args.length !== 2
+				) {
+					return element;
+				}
+				let [ lhs, rhs ] = element.expression.args;
+				if ( lhs.type !== 'operation' ) {
+					// try swapping them
+					[ lhs, rhs ] = [ rhs, lhs ];
+				}
+				if ( lhs.type !== 'operation' ||
+					lhs.operator !== 'year' ||
+					lhs.args.length !== 1 ||
+					lhs.args[ 0 ].termType !== 'Variable' ||
+					rhs.termType !== 'Literal' ||
+					rhs.datatype.value !== 'http://www.w3.org/2001/XMLSchema#integer'
+				) {
+					return element;
+				}
+
+				let year;
+				try {
+					year = parseInt( rhs.value );
+				} catch ( e ) {
+					return element;
+				}
+				if ( year.toString() !== rhs.value ) {
+					// precision issues or garbage at end of input
+					return element;
+				}
+
+				// we actually have an expression of the form FILTER(YEAR(?date) = 2020)
+				// rewrite it to FILTER(?date >= "2020-00-00"^^xsd:dateTime && ?date < "2021-00-00"^^xsd:dateTime)
+				hasChange = true;
+				const variable = lhs.args[ 0 ];
+				const dateTime = {
+					termType: 'NamedNode',
+					value: 'http://www.w3.org/2001/XMLSchema#dateTime',
+				};
+				return {
+					type: 'filter',
+					expression: {
+						type: 'operation',
+						operator: '&&',
+						args: [
+							{
+								type: 'operation',
+								operator: '>=',
+								args: [
+									variable,
+									{
+										termType: 'Literal',
+										value: `${year}-00-00`,
+										language: '',
+										datatype: dateTime,
+									},
+								],
+							},
+							{
+								type: 'operation',
+								operator: '<',
+								args: [
+									variable,
+									{
+										termType: 'Literal',
+										value: `${year + 1}-00-00`,
+										language: '',
+										datatype: dateTime,
+									},
+								],
+							},
+						],
+					},
+				};
+			} ),
+		};
+
+		if ( hasChange ) {
+			return new WdqsRequest( this.generator.stringify( newQuery ) );
+		}
+	}
+
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5618,6 +5618,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "nodemon": "^2.0.4"
   },
   "dependencies": {
-    "sparqljs": "^3.0.3"
+    "sparqljs": "^3.0.3",
+    "traverse": "^0.6.6"
   }
 }

--- a/tests/OptimizingHandler.spec.js
+++ b/tests/OptimizingHandler.spec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const SparqlParser = require( 'sparqljs' ).Parser;
+const { allNamespaces } = require( '../lib/rdfNamespaces' );
+const OptimizingHandler = require( '../lib/OptimizingHandler' );
+const WdqsRequest = require( '../lib/WdqsRequest' );
+
+describe( 'OptimizingHandler', () => {
+
+	const handler = new OptimizingHandler();
+	const parser = new SparqlParser( { prefixes: allNamespaces } );
+
+	it.each( [
+		'ASK {}',
+		'INSERT {} WHERE {}',
+		'SELECT * WHERE { ?s ?p ?o. }',
+		'SELECT (YEAR(?dob) AS ?yob) WHERE { wd:Q42 wdt:P569 ?dob. }',
+		'SELECT ?item WHERE { ?item wdt:P569 ?dob; wdt:P570 ?dod. FILTER(YEAR(?dob) = YEAR(?dod)) }',
+		'SELECT ?item WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 10000000000000000) }',
+		// the following *could* be optimized, just not by the current implementation
+		'SELECT * WHERE { { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) } UNION {} }',
+		'SELECT * WHERE { OPTIONAL { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) } }',
+		'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) > 2020) }',
+		'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020 && MONTH(?dob) = 7) }',
+	] )( 'ignores query it cannot optimize: %s', ( query ) => {
+		expect( handler.handle( query, parser.parse( query ) ) ).toBeFalsy();
+	} );
+
+	it.each( [
+		[
+			'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) }',
+			'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER((?dob >= "2020-00-00"^^xsd:dateTime) && (?dob < "2021-00-00"^^xsd:dateTime)) }',
+		],
+		[
+			'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(2020 = YEAR(?dob)) }',
+			'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER((?dob >= "2020-00-00"^^xsd:dateTime) && (?dob < "2021-00-00"^^xsd:dateTime)) }',
+		],
+	] )( 'optimizes %s into %s', ( query, expected ) => {
+		const result = handler.handle( query, parser.parse( query ) );
+		expect( result ).toBeInstanceOf( WdqsRequest );
+		expect( result.extraResponseHeaders ).toStrictEqual( {} );
+
+		let actual = result.query;
+		actual = actual.replace( /^PREFIX .*$/gm, '' );
+		actual = actual.replace( /\s+/g, ' ' );
+		actual = actual.trim();
+
+		expect( actual ).toBe( expected );
+	} );
+
+} );

--- a/tests/OptimizingHandler.spec.js
+++ b/tests/OptimizingHandler.spec.js
@@ -48,4 +48,13 @@ describe( 'OptimizingHandler', () => {
 		expect( actual ).toBe( expected );
 	} );
 
+	it( 'does not modify the input parsedQuery', () => {
+		const query = 'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) }';
+		const parsedQuery = parser.parse( query );
+
+		handler.handle( query, parsedQuery );
+
+		expect( parsedQuery ).toStrictEqual( parser.parse( query ) );
+	} );
+
 } );

--- a/tests/OptimizingHandler.spec.js
+++ b/tests/OptimizingHandler.spec.js
@@ -18,8 +18,6 @@ describe( 'OptimizingHandler', () => {
 		'SELECT ?item WHERE { ?item wdt:P569 ?dob; wdt:P570 ?dod. FILTER(YEAR(?dob) = YEAR(?dod)) }',
 		'SELECT ?item WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 10000000000000000) }',
 		// the following *could* be optimized, just not by the current implementation
-		'SELECT * WHERE { { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) } UNION {} }',
-		'SELECT * WHERE { OPTIONAL { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) } }',
 		'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) > 2020) }',
 		'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020 && MONTH(?dob) = 7) }',
 	] )( 'ignores query it cannot optimize: %s', ( query ) => {
@@ -34,6 +32,14 @@ describe( 'OptimizingHandler', () => {
 		[
 			'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER(2020 = YEAR(?dob)) }',
 			'SELECT * WHERE { ?item wdt:P569 ?dob. FILTER((?dob >= "2020-00-00"^^xsd:dateTime) && (?dob < "2021-00-00"^^xsd:dateTime)) }',
+		],
+		[
+			'SELECT * WHERE { { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) } UNION {} }',
+			'SELECT * WHERE { { ?item wdt:P569 ?dob. FILTER((?dob >= "2020-00-00"^^xsd:dateTime) && (?dob < "2021-00-00"^^xsd:dateTime)) } UNION { } }',
+		],
+		[
+			'SELECT * WHERE { OPTIONAL { ?item wdt:P569 ?dob. FILTER(YEAR(?dob) = 2020) } }',
+			'SELECT * WHERE { OPTIONAL { ?item wdt:P569 ?dob. FILTER((?dob >= "2020-00-00"^^xsd:dateTime) && (?dob < "2021-00-00"^^xsd:dateTime)) } }',
 		],
 	] )( 'optimizes %s into %s', ( query, expected ) => {
 		const result = handler.handle( query, parser.parse( query ) );


### PR DESCRIPTION
This handler proxies to WDQS after optimizing the query at the SPARQL level. It currently implements a single optimization: a query like

```sparql
SELECT ?item ?dod WHERE {
  ?item wdt:P570 ?dod.
  FILTER(YEAR(?dod) = 2020)
}
LIMIT 100
```

is rewritten to the [equivalent, but more efficient][1]

```sparql
SELECT * WHERE {
  ?item wdt:P570 ?dod.
  FILTER((?dod >= "2020-00-00"^^xsd:dateTime) && (?dod < "2021-00-00"^^xsd:dateTime))
}
LIMIT 100
```

In this case, that seems to speed up the query by roughly one order of magnitude (from 45-50 s to 4-5 s).

To verify that this does the correct thing even for BCE years, try running

```sparql
SELECT ?dod WHERE {
  wd:Q635 wdt:P570 ?dod.
  FILTER(YEAR(?dod) = -29)
}
```

against Queripulator and directly against WDQS.

[1]: https://twitter.com/WikidataFacts/status/752187548219412480

---

This pull request can probably be squashed into one commit when it’s done.