### PR TITLE
Add script for bulk matching queries to query handlers

### DIFF
--- a/bulkMatch.js
+++ b/bulkMatch.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const fs = require( 'fs' );
+const process = require( 'process' );
+const readline = require( 'readline' );
+const parser = require( './lib/sparqlParser' );
+const OptimizingHandler = require( './lib/OptimizingHandler' );
+const SubjectByPropertyValueHandler = require( './lib/SubjectByPropertyValueHandler' );
+const SpecificItemPropertyPairQueryHandler = require( './lib/SpecificItemPropertyPairQueryHandler' );
+
+function getHandlerMatchingQuery( query, handlers ) {
+	for ( const handler of handlers ) {
+		let parsedQuery;
+		try {
+			parsedQuery = parser.parse( query );
+		} catch ( _e ) {
+			return 'parseError';
+		}
+
+		try {
+			if ( handler.handle( query, parsedQuery ) ) {
+				return handler.constructor.name;
+			}
+		} catch ( _e ) {
+			return 'handlerError';
+		}
+	}
+
+	return 'default';
+}
+
+const handlers = [
+	new SpecificItemPropertyPairQueryHandler(),
+	new OptimizingHandler(),
+	new SubjectByPropertyValueHandler(),
+];
+
+const rd = readline.createInterface( {
+	input: fs.createReadStream( process.argv[ 2 ] ),
+	output: process.stdout,
+	terminal: false,
+} );
+
+const matchCounts = {};
+rd.on( 'line', ( line ) => {
+	const csvParts = line.split( ',' );
+	const query = decodeURIComponent( csvParts[ csvParts.length - 1 ].replace( /\+/g, '%20' ) );
+	const handlerForQuery = getHandlerMatchingQuery( query, handlers );
+
+	matchCounts[ handlerForQuery ] = ( matchCounts[ handlerForQuery ] || 0 ) + 1;
+} );
+
+rd.on( 'close', () => {
+	console.log( matchCounts );
+} );


### PR DESCRIPTION
The script can be invoked via `node bulkMatch.js path/to/file.csv`. It
outputs the count per query handler, as well as the number of errors
thrown while parsing the query, number of errors thrown within the query
handlers, and number of queries that didn't match any handlers.

Here are the numbers for the files we got so far:
```
$ docker-compose run --rm node node bulkMatch.js 0722-count.csv 
{
  parseError: 83,
  default: 9703,
  handlerError: 117,
  SpecificItemPropertyPairQueryHandler: 41,
  SubjectByPropertyValueHandler: 56
}
```
and
```
$ docker-compose run --rm node node bulkMatch.js 0722-time.csv 
{
  parseError: 310,
  default: 9654,
  handlerError: 13,
  OptimizingHandler: 20,
  SubjectByPropertyValueHandler: 3
}
```

They take quite a while to run. 0m33,479s for `0722-count.csv` and 1m33,731s for `0722-time.csv`.