### PR TITLE
Handle simple BGP queries using LDF

### DIFF
--- a/lib/LdfHandler.js
+++ b/lib/LdfHandler.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const SparqlGenerator = require( 'sparqljs' ).Generator;
+
+const { allPrefixes } = require( './rdfNamespaces' );
+const LdfRequest = require( './LdfRequest' );
+
+module.exports = class LdfHandler {
+
+	constructor() {
+		this.generator = new SparqlGenerator( { prefixes: allPrefixes } );
+	}
+
+	handle( _query, parsedQuery ) {
+		// In theory, LDF can handle almost any query (except ones with custom SERVICEs),
+		// including with OPTIONALs, FILTERs, etc. (with more or less client-side processing);
+		// we limit it (somewhat arbitrarily) to queries with a single Basic Graph Pattern
+		// (which may have any number of triples).
+		if ( !parsedQuery ||
+			parsedQuery.queryType !== 'SELECT' ||
+			parsedQuery.where.length !== 1 ||
+			parsedQuery.where[ 0 ].type !== 'bgp'
+		) {
+			return;
+		}
+
+		// Bug in ldf-client: if the SparqlIterator is transformed,
+		// the SparqlResultWriter no longer has access to the variables,
+		// so the head will be empty.
+		if ( parsedQuery.distinct || 'offset' in parsedQuery || 'limit' in parsedQuery ) {
+			return;
+		}
+
+		// re-stringify the parsed query to ensure it has all the right prefixes
+		return new LdfRequest( this.generator.stringify( parsedQuery ) );
+	}
+
+};

--- a/lib/LdfRequest.js
+++ b/lib/LdfRequest.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const {
+	FragmentsClient,
+	SparqlIterator,
+	SparqlResultWriter,
+} = require( 'ldf-client' );
+
+module.exports = class LdfRequest {
+
+	constructor( query ) {
+		this.query = query;
+	}
+
+	respond( request, response ) {
+		response.writeHead(
+			200,
+			{
+				'content-type': 'application/sparql-results+json',
+				'queripulator-ldf': 'true',
+			},
+		);
+		const iterator = new SparqlIterator(
+			// do NOT use a parsedQuery here – SparqlIterator *can* take a parsed query,
+			// but uses a completely different version of SPARQL.js than us
+			// and therefore expects the parsed query to look very differently
+			this.query,
+			{
+				fragmentsClient: new FragmentsClient( 'https://query.wikidata.org/bigdata/ldf' ),
+			},
+		);
+		const writer = SparqlResultWriter.instantiate( 'application/sparql-results+json', iterator );
+		writer.on( 'data', ( chunk ) => response.write( chunk ) );
+		writer.on( 'end', () => response.end() );
+		writer.on( 'error', console.error );
+	}
+
+};

--- a/lib/defaultQueryHandlerChain.js
+++ b/lib/defaultQueryHandlerChain.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const LabelServiceHandler = require( './LabelServiceHandler' );
+const LdfHandler = require( './LdfHandler' );
 const OptimizingHandler = require( './OptimizingHandler' );
 const QueryHandlerChain = require( './QueryHandlerChain' );
 const SubjectByPropertyValueHandler = require( './SubjectByPropertyValueHandler' );
@@ -8,6 +9,7 @@ const TruthyHandler = require( './TruthyHandler' );
 
 module.exports = new QueryHandlerChain( [
 	new SubjectByPropertyValueHandler(),
+	new LdfHandler(),
 	new TruthyHandler(),
 	new LabelServiceHandler(),
 	new OptimizingHandler(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,6 +1032,14 @@
         "lodash": "^4.17.14"
       }
     },
+    "asynciterator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-1.1.1.tgz",
+      "integrity": "sha512-NLWjVfwc/I1k/aS9eLH/zfxnN6Ci/WHJiJCfwHcyLlPUnYIY2WHDMYycBIpobyi3qCVGYdqTY4NV0LFURbqZ/g==",
+      "requires": {
+        "immediate": "^3.2.3"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2938,6 +2946,11 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
+    "immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+    },
     "immutable": {
       "version": "4.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
@@ -3955,6 +3968,42 @@
         "package-json": "^6.3.0"
       }
     },
+    "ldf-client": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ldf-client/-/ldf-client-2.0.5.tgz",
+      "integrity": "sha512-1c5oQYjrv78boWe/SkGYKD70Np88m1k1imJm22rlGd/1UDdWgk630yIZDFjZIkrpZBhkNakjIARdHoiHd4gxwA==",
+      "requires": {
+        "asynciterator": "^1.1.0",
+        "follow-redirects": "^1.0.0",
+        "lodash": "^2.4.1",
+        "lru-cache": "^4.0.1",
+        "minimist": "^1.2.0",
+        "n3": "^0.8.1",
+        "negotiator": "^0.6.1",
+        "parse-link-header": "^0.4.1",
+        "setimmediate": "^1.0.4",
+        "sparqljs": "^1.3.0",
+        "uritemplate": "^0.3.0",
+        "xml": ">=1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        },
+        "n3": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/n3/-/n3-0.8.5.tgz",
+          "integrity": "sha1-2tZfiSQOlV+Jpxpsrq5BeFpjbdQ="
+        },
+        "sparqljs": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-1.5.2.tgz",
+          "integrity": "sha512-oKPSYbP/fBomMqMQhHDnAawwW0v4GKyMHnOK1GREAAomcBSIC+zA1UfgSYvePZsuqWgxzGkmsTL5tb6LmiLttw=="
+        }
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4012,6 +4061,15 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "make-dir": {
       "version": "3.1.0",
@@ -4107,8 +4165,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -4190,6 +4247,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4511,6 +4573,14 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-link-header": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.4.1.tgz",
+      "integrity": "sha1-9r1hXcZxP9QJNc6XlF5NP1Iu3xQ=",
+      "requires": {
+        "xtend": "~4.0.0"
+      }
+    },
     "parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -4648,6 +4718,11 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.8.0",
@@ -5199,6 +5274,11 @@
           }
         }
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -6036,6 +6116,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "uritemplate": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/uritemplate/-/uritemplate-0.3.4.tgz",
+      "integrity": "sha1-BdCoU/+8iw9Jqj1NKtd3sNHuBww="
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -6420,6 +6505,12 @@
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "optional": true
+    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -6432,11 +6523,21 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@rdfjs/data-model": "^1.1.2",
     "axios": "^0.19.2",
     "immutable": "^4.0.0-rc.12",
+    "ldf-client": "^2.0.5",
     "nodemw": "^0.13.0",
     "sparqljs": "^3.0.3",
     "sparqljson-parse": "^1.5.2",

--- a/tests/LdfHandler.spec.js
+++ b/tests/LdfHandler.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const parser = require( '../lib/sparqlParser' );
+const LdfHandler = require( '../lib/LdfHandler' );
+const LdfRequest = require( '../lib/LdfRequest' );
+
+describe( 'LdfHandler', () => {
+
+	const handler = new LdfHandler();
+
+	it.each( [
+		'SELECT * WHERE { ?s ?p ?o. }',
+		'SELECT * WHERE { ?item wdt:P31 wd:Q5; wdt:P19 wd:Q4007. }',
+	] )( 'handles basic query: %s', ( query ) => {
+		expect( handler.handle( query, parser.parse( query ) ) )
+			.toBeInstanceOf( LdfRequest );
+	} );
+
+	it.each( [
+		'SELECT * WHERE { BIND(wd:Q5 AS ?class) ?item wdt:P31 ?class. }',
+		`
+SELECT ?item ?itemLabel WHERE {
+  ?item wdt:P31 wd:Q146.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+		`.replace( /\s+/gm, ' ' ).trim(),
+	] )( 'does not handle unsupported query: %s', ( query ) => {
+		expect( handler.handle( query, parser.parse( query ) ) )
+			.toBeFalsy();
+	} );
+
+	it.each( [
+		'SELECT DISTINCT ?item WHERE { ?item wd:P1087 []. }',
+		'SELECT ?item WHERE { ?item wdt:P31 wd:Q5. } LIMIT 10',
+		'SELECT ?item WHERE { ?item wdt:P31 wd:Q146. } OFFSET 0',
+	] )( 'does not handle query that would trigger ldf-client bug: %s', ( query ) => {
+		expect( handler.handle( query, parser.parse( query ) ) )
+			.toBeFalsy();
+	} );
+
+} );


### PR DESCRIPTION
Using the deprecated [ldf-client library][1], because the suggested replacement Comunica has [a bug which prevents it from communicating with the Wikidata LDF service][2]. ldf-client also turns out to have a bug – if the query uses DISTINCT, LIMIT, or OFFSET, the results lose their head – but that one is easier to work around.

[1]: https://github.com/LinkedDataFragments/Client.js
[2]: https://github.com/comunica/comunica/issues/700