### PR TITLE
Add SubjectByPropertyAnyValueHandler

### DIFF
--- a/lib/CirrusSearchRequest.js
+++ b/lib/CirrusSearchRequest.js
@@ -4,14 +4,14 @@ const nodemw = require( './nodemw' );
 
 module.exports = class CirrusSearchRequest {
 
-	constructor( resultColumnName, property, value ) {
+	constructor( resultColumnName, property, value = null ) {
 		this.resultColumnName = resultColumnName;
 		this.property = property;
 		this.value = value;
 	}
 
 	respond( request, response ) {
-		const search = `haswbstatement:${this.property}=${this.value}`;
+		const search = this.getCirrusSearchString();
 		nodemw.getAll(
 			{
 				action: 'query',
@@ -39,6 +39,14 @@ module.exports = class CirrusSearchRequest {
 					this.transformToQueryResultFormat( searchResults ),
 				) );
 			} );
+	}
+
+	getCirrusSearchString() {
+		if ( this.value !== null ) {
+			return `haswbstatement:${this.property}=${this.value}`;
+		}
+
+		return `haswbstatement:${this.property}`;
 	}
 
 	transformToQueryResultFormat( searchHits ) {

--- a/lib/SubjectByPropertyAnyValueHandler.js
+++ b/lib/SubjectByPropertyAnyValueHandler.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { namespaceMap } = require( './rdfNamespaces' );
+const hasSingleTriple = require( './hasSingleTriple' );
+const CirrusSearchRequest = require( './CirrusSearchRequest' );
+
+module.exports = class SubjectByPropertyAnyValueHandler {
+	handle( _query, parsedQuery ) {
+		if ( !parsedQuery ||
+			parsedQuery.queryType !== 'SELECT' ||
+			parsedQuery.variables.length !== 1 ||
+			parsedQuery.variables[ 0 ].termType !== 'Variable' ||
+			!hasSingleTriple( parsedQuery ) ) {
+			return false;
+		}
+		const triple = parsedQuery.where[ 0 ].triples[ 0 ];
+		if ( triple.subject.termType !== 'Variable' ||
+			triple.subject.id !== parsedQuery.variables[ 0 ].id ||
+			triple.predicate.termType !== 'NamedNode' ||
+			!triple.predicate.id.startsWith( namespaceMap.Wikidata.wdt ) ||
+			!(
+				triple.object.termType === 'BlankNode' ||
+				triple.object.termType === 'Variable' &&
+				triple.object.id !== parsedQuery.variables[ 0 ].id
+			) ) {
+			return false;
+		}
+
+		return new CirrusSearchRequest(
+			triple.subject.id.substring( 1 ),
+			triple.predicate.id.substring( namespaceMap.Wikidata.wdt.length ),
+		);
+	}
+};

--- a/lib/defaultQueryHandlerChain.js
+++ b/lib/defaultQueryHandlerChain.js
@@ -5,10 +5,12 @@ const LdfHandler = require( './LdfHandler' );
 const OptimizingHandler = require( './OptimizingHandler' );
 const QueryHandlerChain = require( './QueryHandlerChain' );
 const SubjectByPropertyValueHandler = require( './SubjectByPropertyValueHandler' );
+const SubjectByPropertyAnyValueHandler = require( './SubjectByPropertyAnyValueHandler' );
 const TruthyHandler = require( './TruthyHandler' );
 
 module.exports = new QueryHandlerChain( [
 	new SubjectByPropertyValueHandler(),
+	new SubjectByPropertyAnyValueHandler(),
 	new LdfHandler(),
 	new TruthyHandler(),
 	new LabelServiceHandler(),

--- a/tests/SubjectByPropertyAnyValueHandler.spec.js
+++ b/tests/SubjectByPropertyAnyValueHandler.spec.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const parser = require( '../lib/sparqlParser' );
+const SubjectByPropertyAnyValueHandler = require( '../lib/SubjectByPropertyAnyValueHandler' );
+const CirrusSearchRequest = require( '../lib/CirrusSearchRequest' );
+
+describe( 'SubjectByPropertyAnyValueHandler', () => {
+
+	it.each( [
+		[ 'ASK {}' ],
+		[ 'INSERT {} WHERE {}' ],
+		[ 'SELECT * WHERE { ?s ?p ?o. }' ],
+		[ 'SELECT ?item WHERE { ?item wdt:P31 wd:Q5. }' ],
+		[ 'SELECT ?item (NOW() AS ?asOf) WHERE { ?item wdt:P123 [] }' ],
+		[ 'SELECT ?item ?value WHERE { ?item wdt:P345 ?value. }' ],
+		[ 'SELECT ?item WHERE { ?item wdt:P345 ?item. }' ],
+	] )( 'does not handle query: %s', ( query ) => {
+		const handler = new SubjectByPropertyAnyValueHandler();
+		expect( handler.handle( query, parser.parse( query ) ) ).toBeFalsy();
+	} );
+
+	it.each( [
+		[ 'SELECT ?item WHERE { ?item wdt:P345 [] }' ],
+		[ 'SELECT ?item WHERE { ?item wdt:P345 _:b. }' ],
+		[ 'SELECT ?item WHERE { ?item wdt:P345 ?notSelected. }' ],
+	] )( 'creates a CirrusSearchRequest from query: %s', ( query ) => {
+		const handler = new SubjectByPropertyAnyValueHandler();
+		expect( handler.handle( query, parser.parse( query ) ) )
+			.toBeInstanceOf( CirrusSearchRequest );
+	} );
+
+} );


### PR DESCRIPTION
Adds another query handler that requests data from Cirrus. Handles
queries with single triples that look for entities with statements for
a given property with any value, e.g. `?lexeme wdt:P5191 [] .`.

Slightly concerning: I'm getting more results using LDF than with this handler.

Example:
```sparql
SELECT ?lexeme WHERE {
 ?lexeme wdt:P5191 [] .
}
```
gets me `4838 results in 10824 ms` from the `CirrusSearchRequest`, and `5106 results in 15941 ms` from LDF.